### PR TITLE
Set DBF default character encoding to ISO-8859-1

### DIFF
--- a/lib/BinaryReader.js
+++ b/lib/BinaryReader.js
@@ -1,11 +1,13 @@
-var fs = require('fs');
+var fs = require('fs'),
+    iconv = require('iconv-lite');
 
-var BinaryReader = function(file) {
+var BinaryReader = function(file, encoding) {
   this.offset = 0;
   this._buffer = fs.readFileSync(file);
   this.lastRecord = null;
   this.length = this._buffer.length;
   this.bigEndian = false;
+  this.stringEncoding = encoding || 'utf8';
 }
 
 BinaryReader.prototype = {
@@ -91,10 +93,9 @@ BinaryReader.prototype = {
     return val;
   },
   readString: function(length, encoding) {
-    var encoding = encoding || 'utf8';
-    var val = this._buffer.toString(encoding, this.offset, this.offset + length);
+    var buf = this._buffer.slice(this.offset, this.offset + length);
     this.offset += length;
-    return val;
+    return iconv.decode(buf, this.stringEncoding);
   }
 }
 

--- a/lib/dbf.js
+++ b/lib/dbf.js
@@ -5,8 +5,21 @@ var fs = require('fs');
 var BinaryReader = require('./BinaryReader');
 
 function DbfFile(path) {
+  // The DBF standard specifies ISO-8859-1 as the only supported encoding.
+  var encoding = 'iso88591';
+
+  // However ArcGIS and some other shape readers can specify an alternative
+  // encoding through an extra .cpg file.
+  if(fs.existsSync(path + '.cpg')) {
+    encoding = fs.readFileSync(path + '.cpg', 'ascii').trim();
+  } else if(fs.existsSync(path + '.cst')) {
+    // Geoserver WFS export has a similar encoding specification but uses .cst
+    // as the file extension.
+    encoding = fs.readFileSync(path + '.cst', 'ascii').trim();
+  }
+
   this.header = {}
-  this.reader = new BinaryReader(path + ".dbf");
+  this.reader = new BinaryReader(path + ".dbf", encoding);
 
   var t1 = Date.now();
 
@@ -122,7 +135,7 @@ function DbfRecord(reader, header) {
   this.values = {}
   for (var i = 0; i < header.fields.length; i++) {
     var field = header.fields[i];
-    this.values[field.name] = reader.readString(field.length);
+    this.values[field.name] = reader.readString(field.length).trim();
   }
 }
 module.exports = DbfFile;

--- a/lib/shp.js
+++ b/lib/shp.js
@@ -4,6 +4,13 @@
 var fs = require('fs');
 var BinaryReader = require('./BinaryReader');
 
+function isClockwise(points) {
+  return points.reduce(function (sum, c, i, points) {
+    var n = points[(i+1)%points.length];
+    return sum + (n.x-c.x)*(n.y+c.y);
+  }, 0) >= 0;
+}
+
 var ShpFile = function(path) {
   this.header = {};
   this._reader = new BinaryReader(path+".shp");
@@ -266,7 +273,7 @@ function ShpPolyline(reader, size) {
 
     reader.bigEndian = false;
 
-    this.box = { 
+    this.box = {
       x: reader.readDouble(),
       y: reader.readDouble(),
       width: reader.readDouble(),
@@ -289,14 +296,18 @@ function ShpPolyline(reader, size) {
 
     // convert points, and ringOffsets arrays to an array of rings:
     var removed = 0;
-    var split;
+    var split, ring;
     ringOffsets.shift();
     while(ringOffsets.length) {
       split = ringOffsets.shift();
-      this.rings.push(points.splice(0,split-removed));
+      ring = points.splice(0,split-removed);
+      ring.isClockwise = isClockwise(ring);
+      this.rings.push(ring);
       removed = split;
     }
-    this.rings.push(points);
+    ring = points;
+    ring.isClockwise = isClockwise(ring);
+    this.rings.push(ring);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
   "name" : "shp",
   "description" : "Convert shapefiles into geoJson without ogr2ogr/GDAL",
-  "version" : "0.0.1",
+  "version" : "0.0.2",
   "repository" : {
     "type" : "git",
-    "url" : "git://github.com/yuletide/node-shp"
+    "url" : "git://github.com/icetan/node-shp"
   },
   "main" : "index.js",
   "engines" : {
-    "node" : ">=0.6.x",
-    "npm" : "1.1.x"
+    "node" : ">=0.6",
+    "npm" : "~1.2.0"
   },
   "keywords" : ["shp", "esri", "shapefile", "geo", "geojson", "mapping"],
+  "dependencies": {
+    "iconv-lite": "~0.2.7"
+  },
   "devDependencies": {
     "mocha":  "~1.4.1",
     "chai": "~1.2.0",
@@ -22,6 +25,7 @@
     "email" : "alexy@codeforamerica.org",
     "url" : "http://alexyule.com"
   },
+  "contributors": ["Christopher Fredén"],
   "scripts" : {
     "test" : "mocha"
   }

--- a/test/shp.spec.js
+++ b/test/shp.spec.js
@@ -8,10 +8,11 @@ describe('Shapefile Reader', function() {
   it('Can correctly convert multiPolygon shapefile to GeoJSON', function(done){
     var good_json = JSON.parse(fs.readFileSync(__dirname + '/data/multipolygon.json', "utf8"));
     shpFile.readFile(__dirname + '/data/multipolygon', function(error, data){
-      expect(data.features[0].geometry.coordinates[0][0][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][0], 0.00001);
-      expect(data.features[0].geometry.coordinates[0][0][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][1], 0.00001);
-      expect(data.features[0].geometry.coordinates[0][1][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][1][0], 0.00001);
-      expect(data.features[0].geometry.coordinates[0][1][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][1][1], 0.00001);
+      expect(data.features[0].geometry.type).to.equal('MultiPolygon');
+      expect(data.features[0].geometry.coordinates[0][0][0][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][0][0], 0.00001);
+      expect(data.features[0].geometry.coordinates[0][0][0][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][0][1], 0.00001);
+      expect(data.features[0].geometry.coordinates[0][0][1][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][1][0], 0.00001);
+      expect(data.features[0].geometry.coordinates[0][0][1][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][1][1], 0.00001);
     });
     done();
   });


### PR DESCRIPTION
Got some encoding problems when adding å/ä/ö in my shape data. Turns out the only supported encoding for DBF (by the original spec.) is ISO-8859-1.

There have been some extensions to the specifications and I tried to accommodate them as well.

I had to add a dependency on Iconv to decode ISO-8859-1.

This was a helpful post: http://gis.stackexchange.com/questions/3529/which-character-encoding-is-used-by-the-dbf-file-in-shapefiles
