### PR TITLE
Set DBF default character encoding to ISO-8859-1

### DIFF
--- a/lib/BinaryReader.js
+++ b/lib/BinaryReader.js
@@ -1,11 +1,13 @@
-var fs = require('fs');
+var fs = require('fs'),
+    iconv = require('iconv-lite');
 
-var BinaryReader = function(file) {
+var BinaryReader = function(file, encoding) {
   this.offset = 0;
   this._buffer = fs.readFileSync(file);
   this.lastRecord = null;
   this.length = this._buffer.length;
   this.bigEndian = false;
+  this.stringEncoding = encoding || 'utf8';
 }
 
 BinaryReader.prototype = {
@@ -91,10 +93,9 @@ BinaryReader.prototype = {
     return val;
   },
   readString: function(length, encoding) {
-    var encoding = encoding || 'utf8';
-    var val = this._buffer.toString(encoding, this.offset, this.offset + length);
+    var buf = this._buffer.slice(this.offset, this.offset + length);
     this.offset += length;
-    return val;
+    return iconv.decode(buf, this.stringEncoding);
   }
 }
 

--- a/lib/dbf.js
+++ b/lib/dbf.js
@@ -5,8 +5,21 @@ var fs = require('fs');
 var BinaryReader = require('./BinaryReader');
 
 function DbfFile(path) {
+  // The DBF standard specifies ISO-8859-1 as the only supported encoding.
+  var encoding = 'iso88591';
+
+  // However ArcGIS and some other shape readers can specify an alternative
+  // encoding through an extra .cpg file.
+  if(fs.existsSync(path + '.cpg')) {
+    encoding = fs.readFileSync(path + '.cpg', 'ascii').trim();
+  } else if(fs.existsSync(path + '.cst')) {
+    // Geoserver WFS export has a similar encoding specification but uses .cst
+    // as the file extension.
+    encoding = fs.readFileSync(path + '.cst', 'ascii').trim();
+  }
+
   this.header = {}
-  this.reader = new BinaryReader(path + ".dbf");
+  this.reader = new BinaryReader(path + ".dbf", encoding);
 
   var t1 = Date.now();
 
@@ -122,7 +135,7 @@ function DbfRecord(reader, header) {
   this.values = {}
   for (var i = 0; i < header.fields.length; i++) {
     var field = header.fields[i];
-    this.values[field.name] = reader.readString(field.length);
+    this.values[field.name] = reader.readString(field.length).trim();
   }
 }
 module.exports = DbfFile;

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
   "name" : "shp",
   "description" : "Convert shapefiles into geoJson without ogr2ogr/GDAL",
-  "version" : "0.0.1",
+  "version" : "0.0.2",
   "repository" : {
     "type" : "git",
-    "url" : "git://github.com/yuletide/node-shp"
+    "url" : "git://github.com/icetan/node-shp"
   },
   "main" : "index.js",
   "engines" : {
-    "node" : ">=0.6.x",
-    "npm" : "1.1.x"
+    "node" : ">=0.6",
+    "npm" : "~1.2.0"
   },
   "keywords" : ["shp", "esri", "shapefile", "geo", "geojson", "mapping"],
+  "dependencies": {
+    "iconv-lite": "~0.2.7"
+  },
   "devDependencies": {
     "mocha":  "~1.4.1",
     "chai": "~1.2.0",
@@ -22,6 +25,7 @@
     "email" : "alexy@codeforamerica.org",
     "url" : "http://alexyule.com"
   },
+  "contributors": ["Christopher Fredén"],
   "scripts" : {
     "test" : "mocha"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version" : "0.0.2",
   "repository" : {
     "type" : "git",
-    "url" : "git://github.com/icetan/node-shp"
+    "url" : "git://github.com/yuletide/node-shp"
   },
   "main" : "index.js",
   "engines" : {


### PR DESCRIPTION
Got some encoding problems when adding å/ä/ö in my shape data. Turns out the only supported encoding for DBF (by the original spec.) is ISO-8859-1.

There have been some extensions to the specifications and I tried to accommodate them as well.

I had to add a dependency on Iconv to decode ISO-8859-1.

This was a helpful post: http://gis.stackexchange.com/questions/3529/which-character-encoding-is-used-by-the-dbf-file-in-shapefiles
