### PR TITLE
Added support for GeoJSON MultiPolygon with holes

### DIFF
--- a/lib/shp.js
+++ b/lib/shp.js
@@ -4,6 +4,13 @@
 var fs = require('fs');
 var BinaryReader = require('./BinaryReader');
 
+function isClockwise(points) {
+  return points.reduce(function (sum, c, i, points) {
+    var n = points[(i+1)%points.length];
+    return sum + (n.x-c.x)*(n.y+c.y);
+  }, 0) >= 0;
+}
+
 var ShpFile = function(path) {
   this.header = {};
   this._reader = new BinaryReader(path+".shp");
@@ -266,7 +273,7 @@ function ShpPolyline(reader, size) {
 
     reader.bigEndian = false;
 
-    this.box = { 
+    this.box = {
       x: reader.readDouble(),
       y: reader.readDouble(),
       width: reader.readDouble(),
@@ -289,14 +296,18 @@ function ShpPolyline(reader, size) {
 
     // convert points, and ringOffsets arrays to an array of rings:
     var removed = 0;
-    var split;
+    var split, ring;
     ringOffsets.shift();
     while(ringOffsets.length) {
       split = ringOffsets.shift();
-      this.rings.push(points.splice(0,split-removed));
+      ring = points.splice(0,split-removed);
+      ring.isClockwise = isClockwise(ring);
+      this.rings.push(ring);
       removed = split;
     }
-    this.rings.push(points);
+    ring = points;
+    ring.isClockwise = isClockwise(ring);
+    this.rings.push(ring);
   }
 }
 

--- a/test/shp.spec.js
+++ b/test/shp.spec.js
@@ -8,10 +8,11 @@ describe('Shapefile Reader', function() {
   it('Can correctly convert multiPolygon shapefile to GeoJSON', function(done){
     var good_json = JSON.parse(fs.readFileSync(__dirname + '/data/multipolygon.json', "utf8"));
     shpFile.readFile(__dirname + '/data/multipolygon', function(error, data){
-      expect(data.features[0].geometry.coordinates[0][0][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][0], 0.00001);
-      expect(data.features[0].geometry.coordinates[0][0][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][1], 0.00001);
-      expect(data.features[0].geometry.coordinates[0][1][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][1][0], 0.00001);
-      expect(data.features[0].geometry.coordinates[0][1][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][1][1], 0.00001);
+      expect(data.features[0].geometry.type).to.equal('MultiPolygon');
+      expect(data.features[0].geometry.coordinates[0][0][0][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][0][0], 0.00001);
+      expect(data.features[0].geometry.coordinates[0][0][0][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][0][1], 0.00001);
+      expect(data.features[0].geometry.coordinates[0][0][1][0]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][1][0], 0.00001);
+      expect(data.features[0].geometry.coordinates[0][0][1][1]).to.be.closeTo(good_json.features[0].geometry.coordinates[0][0][1][1], 0.00001);
     });
     done();
   });


### PR DESCRIPTION
To determine if a polygon has multiple parts with or without holes I walk each ring and each time a clockwise ring is parsed it is added as a new polygon part. Each time a counter-clockwise ring appears it is added to the previously parsed clockwise ring and forms only one polygon together with holes.

If there is more than one clockwise ring in a feature the geometry type is set to "MultiPolygon".

I used this this file as reference (page nr. 8): http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
